### PR TITLE
[Feat] #16 - 퀴즈 화면 기본 UI 구성

### DIFF
--- a/WordPalette/WordPalette/Presentation/Quiz/Components/QuizStatusView.swift
+++ b/WordPalette/WordPalette/Presentation/Quiz/Components/QuizStatusView.swift
@@ -1,0 +1,135 @@
+//
+//  QuizStatusView.swift
+//  WordPalette
+//
+//  Created by 박주성 on 5/22/25.
+//
+
+import UIKit
+import Then
+import SnapKit
+
+final class QuizStatusView: UIView {
+    
+    // MARK: - UI Components
+    
+    /// 남은 단어 수
+    private let remainingWordCountLabel = UILabel().then {
+        $0.text = "10개"
+        $0.font = .boldSystemFont(ofSize: 24)
+        $0.textColor = .black
+        $0.textAlignment = .center
+    }
+    
+    /// 남은 단어 타이틀
+    private let remainingWordTitleLabel = UILabel().then {
+        $0.text = "남은 단어"
+        $0.font = .systemFont(ofSize: 14)
+        $0.textColor = .gray
+        $0.textAlignment = .center
+    }
+    
+    /// 맞춘 단어 수
+    private let correctWordCountLabel = UILabel().then {
+        $0.text = "5개"
+        $0.font = .boldSystemFont(ofSize: 24)
+        $0.textColor = .black
+        $0.textAlignment = .center
+    }
+    
+    /// 맞춘 단어 타이틀
+    private let correctWordTitleLabel = UILabel().then {
+        $0.text = "맞춘 단어"
+        $0.font = .systemFont(ofSize: 14)
+        $0.textColor = .gray
+        $0.textAlignment = .center
+    }
+    
+    /// 틀린 단어 수
+    private let incorrectWordCountLabel = UILabel().then {
+        $0.text = "3개"
+        $0.font = .boldSystemFont(ofSize: 24)
+        $0.textColor = .black
+        $0.textAlignment = .center
+    }
+    
+    /// 틀린 단어 타이틀
+    private let incorrectWordTitleLabel = UILabel().then {
+        $0.text = "틀린 단어"
+        $0.font = .systemFont(ofSize: 14)
+        $0.textColor = .gray
+        $0.textAlignment = .center
+    }
+    
+    /// 남은 단어 수직 스택뷰
+    private lazy var remainingStatStack = UIStackView(arrangedSubviews: [
+        remainingWordCountLabel,
+        remainingWordTitleLabel
+    ]).then {
+        $0.axis = .vertical
+        $0.spacing = 4
+    }
+    
+    /// 맞춘 단어 수직 스택뷰
+    private lazy var correctStatStack = UIStackView(arrangedSubviews: [
+        correctWordCountLabel,
+        correctWordTitleLabel
+    ]).then {
+        $0.axis = .vertical
+        $0.spacing = 4
+    }
+    
+    /// 틀린 단어 수직 스택뷰
+    private lazy var incorrectStatStack = UIStackView(arrangedSubviews: [
+        incorrectWordCountLabel,
+        incorrectWordTitleLabel
+    ]).then {
+        $0.axis = .vertical
+        $0.spacing = 4
+    }
+    
+    /// 전체 수평 스택
+    private lazy var quizSummaryStack = UIStackView(arrangedSubviews: [
+        remainingStatStack,
+        correctStatStack,
+        incorrectStatStack
+    ]).then {
+        $0.axis = .horizontal
+        $0.spacing = 0
+        $0.distribution = .fillEqually
+    }
+    
+    // MARK: - Initailizer
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+private extension QuizStatusView {
+    func configure() {
+        setAttributes()
+        setHierarchy()
+        setConstraints()
+    }
+    
+    func setAttributes() {
+        backgroundColor = .white
+    }
+    
+    func setHierarchy() {
+        addSubview(quizSummaryStack)
+    }
+    
+    func setConstraints() {
+        quizSummaryStack.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+}

--- a/WordPalette/WordPalette/Presentation/Quiz/Components/WordCardView.swift
+++ b/WordPalette/WordPalette/Presentation/Quiz/Components/WordCardView.swift
@@ -8,8 +8,16 @@
 import UIKit
 import Then
 import SnapKit
+import RxSwift
+import RxCocoa
 
 final class WordCardView: UIView {
+    
+    // MARK: - Propeties
+    
+    private let disposeBag = DisposeBag()
+    
+    private var isFront: Bool = true
     
     // MARK: - UI Components
     
@@ -57,6 +65,17 @@ final class WordCardView: UIView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    private func handleCardFlip() {
+        isFront.toggle()
+        
+        UIView.transition(
+            with: self,
+            duration: 0.5,
+            options: isFront ? .transitionFlipFromRight : .transitionFlipFromLeft) {
+                self.backgroundColor = self.isFront ? .white : .customMango
+            }
+    }
 }
 
 // MARK: - Configure
@@ -66,6 +85,7 @@ private extension WordCardView {
         setAttributes()
         setHierarchy()
         setConstraints()
+        setBindings()
     }
     
     func setAttributes() {
@@ -94,5 +114,13 @@ private extension WordCardView {
             $0.bottom.equalToSuperview()
             $0.height.equalTo(60)
         }
+    }
+    
+    private func setBindings() {
+        translationHintButton.rx.tap
+            .bind(with: self) { owner, _  in
+                owner.handleCardFlip()
+            }
+            .disposed(by: disposeBag)
     }
 }

--- a/WordPalette/WordPalette/Presentation/Quiz/Components/WordCardView.swift
+++ b/WordPalette/WordPalette/Presentation/Quiz/Components/WordCardView.swift
@@ -1,0 +1,98 @@
+//
+//  WordCardView.swift
+//  WordPalette
+//
+//  Created by 박주성 on 5/22/25.
+//
+
+import UIKit
+import Then
+import SnapKit
+
+final class WordCardView: UIView {
+    
+    // MARK: - UI Components
+    
+    /// 단어 (ex. Apple)
+    private let wordLabel = UILabel().then {
+        $0.text = "Apple"
+        $0.textColor = .black
+        $0.textAlignment = .center
+        $0.font = .systemFont(ofSize: 32, weight: .bold)
+    }
+    
+    /// 에문 (ex. I ate an apple)
+    private let exampleLabel = UILabel().then {
+        $0.text = "I ate an apple"
+        $0.textColor = .darkGray
+        $0.textAlignment = .center
+        $0.font = .systemFont(ofSize: 15)
+    }
+    
+    /// 수직 스택뷰 (단어, 예문)
+    private lazy var wordStackView = UIStackView(
+        arrangedSubviews: [
+            wordLabel,
+            exampleLabel
+        ]
+    ).then {
+        $0.axis = .vertical
+        $0.spacing = 8
+    }
+    
+    /// 번역 확인 버튼
+    private let translationHintButton = UIButton().then {
+        $0.setTitle("터치해서 번역 확인", for: .normal)
+        $0.titleLabel?.font = .systemFont(ofSize: 20, weight: .semibold)
+        $0.setTitleColor(.gray, for: .normal)
+    }
+    
+    // MARK: - Initailizer
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Configure
+
+private extension WordCardView {
+    func configure() {
+        setAttributes()
+        setHierarchy()
+        setConstraints()
+    }
+    
+    func setAttributes() {
+        backgroundColor = .white
+        
+        layer.cornerRadius = 20
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOpacity = 0.25
+        layer.shadowOffset = CGSize(width: 0, height: 4)
+        layer.shadowRadius = 4
+        layer.masksToBounds = false
+    }
+    
+    func setHierarchy() {
+        [wordStackView, translationHintButton].forEach { addSubview($0) }
+    }
+    
+    func setConstraints() {
+        wordStackView.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview().inset(20)
+            $0.centerY.equalToSuperview()
+        }
+        
+        translationHintButton.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview().inset(20)
+            $0.bottom.equalToSuperview()
+            $0.height.equalTo(60)
+        }
+    }
+}

--- a/WordPalette/WordPalette/Presentation/Quiz/QuizView.swift
+++ b/WordPalette/WordPalette/Presentation/Quiz/QuizView.swift
@@ -1,0 +1,115 @@
+//
+//  QuizView.swift
+//  WordPalette
+//
+//  Created by 박주성 on 5/22/25.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+final class QuizView: UIView {
+    
+    // MARK: - UI Components
+    
+    /// 퀴즈 화면 상단 타이틀 레이블 ("퀴즈 시간")
+    private let titleLabel = UILabel().then {
+        $0.text = "퀴즈 시간"
+        $0.textColor = .black
+        $0.textAlignment = .center
+        $0.font = .systemFont(ofSize: 32, weight: .bold)
+    }
+    
+    /// 단어 카드 뷰 (퀴즈 문제 출제 영역)
+    private let wordCardView = WordCardView()
+    
+    /// 사용자가 "외웠어요!" 선택 시 누르는 버튼 (정답 처리용)
+    private let correctButton = UIButton().then {
+        $0.setTitle("← 외웠어요 !", for: .normal)
+        $0.titleLabel?.font = .systemFont(ofSize: 18, weight: .semibold)
+        $0.setTitleColor(.gray, for: .normal)
+        $0.contentHorizontalAlignment = .left
+    }
+    
+    /// 사용자가 "못 외웠어요" 선택 시 누르는 버튼 (오답 처리용)
+    private let incorrectButton = UIButton().then {
+        $0.setTitle("못 외웠어요 →", for: .normal)
+        $0.titleLabel?.font = .systemFont(ofSize: 18, weight: .semibold)
+        $0.setTitleColor(.gray, for: .normal)
+        $0.contentHorizontalAlignment = .right
+    }
+    
+    /// 수평 스택뷰 (정답, 오답)
+    private lazy var choiceStackView = UIStackView(
+        arrangedSubviews: [
+            correctButton,
+            incorrectButton
+        ]
+    ).then {
+        $0.axis = .horizontal
+        $0.spacing = 0
+        $0.distribution = .fillEqually
+    }
+    
+    private let quizStatusView = QuizStatusView()
+    
+    // MARK: - Initailizer
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+// MARK: - Configure
+
+private extension QuizView {
+    func configure() {
+        setAttributes()
+        setHierarchy()
+        setConstraints()
+    }
+    
+    func setAttributes() {
+        backgroundColor = .white
+    }
+    
+    func setHierarchy() {
+        [
+            titleLabel,
+            wordCardView,
+            choiceStackView,
+            quizStatusView,
+        ].forEach { addSubview($0) }
+    }
+    
+    func setConstraints() {
+        titleLabel.snp.makeConstraints {
+            $0.top.equalTo(safeAreaLayoutGuide).inset(20)
+            $0.centerX.equalToSuperview()
+        }
+        
+        wordCardView.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(20)
+            $0.horizontalEdges.equalToSuperview().inset(50)
+            $0.height.equalTo(wordCardView.snp.width).multipliedBy(1.6).priority(.low)
+        }
+        
+        choiceStackView.snp.makeConstraints {
+            $0.top.equalTo(wordCardView.snp.bottom).offset(15)
+            $0.horizontalEdges.equalToSuperview().inset(30)
+        }
+        
+        quizStatusView.snp.makeConstraints {
+            $0.top.greaterThanOrEqualTo(choiceStackView.snp.bottom).offset(20)
+            $0.horizontalEdges.equalToSuperview().inset(20)
+            $0.bottom.equalToSuperview().inset(100)
+        }
+    }
+}

--- a/WordPalette/WordPalette/Presentation/Quiz/QuizViewController.swift
+++ b/WordPalette/WordPalette/Presentation/Quiz/QuizViewController.swift
@@ -1,0 +1,42 @@
+//
+//  QuizViewController.swift
+//  WordPalette
+//
+//  Created by 박주성 on 5/22/25.
+//
+
+import UIKit
+
+final class QuizViewController: UIViewController {
+    
+    // MARK: - UI Components
+    
+    private let quizView = QuizView()
+    
+    // MARK: - Life Cycle
+    
+    override func loadView() {
+        view = quizView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configure()
+    }
+
+}
+
+private extension QuizViewController {
+    func configure() {
+        setAttributes()
+        setBindings()
+    }
+    
+    func setAttributes() {
+        
+    }
+    
+    func setBindings() {
+        
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #16 

## 📌 변경 사항 및 이유
- `WordCardView`, `QuizStatusView`, `QuizView` UI 구현
- 힌트 버튼을 탭했을 때, 카드가 앞/뒤로 회전하는 애니메이션을 추가

## 📌 구현 내역 스크린샷
|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src = "https://github.com/user-attachments/assets/85e98e1a-d023-4ea3-bdd8-817b78b478c3" width ="250">|
| iPhone SE 3 | <img src = "https://github.com/user-attachments/assets/9f4086e1-34d4-4bbe-9ed3-201d20f09d26" width ="250">|

## 📌 PR Point
- `priority`, `greaterThanOrEqualTo` 제약조건을 사용하여 작은 화면에서도 뷰가 잘리지 않고 레이아웃이 유동적으로 조정되도록 구현했습니다.

## 📌 참고 사항
- 애니메이션은 UIView.transition을 사용했으며, isFront 상태에 따라 flip 방향을 다르게 설정
- 애니메이션 시 그림자로 인한 원인으로 추정되는 반짝거리는 현상이 있습니다. 추후 수정해서 PR 올리겠습니다.