### PR TITLE
[Fix] - #28 UI 향상 

### DIFF
--- a/WordPalette/WordPalette/App/SceneDelegate.swift
+++ b/WordPalette/WordPalette/App/SceneDelegate.swift
@@ -42,6 +42,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let studyHistoryVC = DIContainer.makeStudyHistoryViewContoller()
         studyHistoryVC.tabBarItem = UITabBarItem(title: "나의 학습", image: UIImage(systemName: "calendar"), tag: 2)
         
+        tabBar.overrideUserInterfaceStyle = .light
         tabBar.selectedIndex = 0
         tabBar.tabBar.tintColor = .customMango
         tabBar.viewControllers = [homeVC, quizVC, studyHistoryVC]

--- a/WordPalette/WordPalette/Presentation/MyStudy/View/ProfileSectionView.swift
+++ b/WordPalette/WordPalette/Presentation/MyStudy/View/ProfileSectionView.swift
@@ -13,7 +13,7 @@ import SnapKit
 final class ProfileSectionView: UIView, UIViewGuide {
     
     /// 메달
-    private let profileLabel = PaddingLabel(top: -4, left: 8, bottom: 10, right: 8)
+    private let profileLabel = PaddingLabel(top: -4, left: 7, bottom: 10, right: 7)
     
     /// 티어
     private let tierLabel = UILabel()
@@ -36,8 +36,8 @@ final class ProfileSectionView: UIView, UIViewGuide {
         backgroundColor = .white
         
         profileLabel.do {
-            $0.font = .systemFont(ofSize: 54, weight: .medium)
-            $0.layer.cornerRadius = 35
+            $0.font = .systemFont(ofSize: UIDevice.current.isiPhoneSE ? 42 : 54, weight: .medium)
+            $0.layer.cornerRadius = UIDevice.current.isiPhoneSE ? 30 : 35
             $0.clipsToBounds = true
         }
         
@@ -65,29 +65,28 @@ final class ProfileSectionView: UIView, UIViewGuide {
             $0.textColor = .black
             $0.font = .systemFont(ofSize: 14, weight: .medium)
         }
-        
     }
     
     func configureLayout() {
         profileLabel.snp.makeConstraints {
-            $0.top.leading.equalToSuperview().inset(24)
+            $0.top.equalToSuperview().inset(UIDevice.current.isiPhoneSE ? 18 : 24)
+            $0.leading.equalToSuperview().inset(UIDevice.current.isiPhoneSE ? 40 : 24)
         }
         
         tierStackView.snp.makeConstraints {
-            $0.leading.equalTo(profileLabel.snp.trailing).offset(24)
+            $0.leading.equalTo(profileLabel.snp.trailing).offset(UIDevice.current.isiPhoneSE ? 18 : 24)
             $0.centerY.equalTo(profileLabel)
         }
         
         remainingTierProgressView.snp.makeConstraints {
             $0.top.equalTo(profileLabel.snp.bottom).offset(16)
-            $0.horizontalEdges.equalToSuperview().inset(24)
+            $0.horizontalEdges.equalToSuperview().inset(UIDevice.current.isiPhoneSE ? 40 : 24)
             $0.height.equalTo(8)
         }
         
         remainingNextTierLabel.snp.makeConstraints {
             $0.top.equalTo(remainingTierProgressView.snp.bottom).offset(8)
-            $0.trailing.equalToSuperview().inset(24)
-            $0.bottom.equalToSuperview().inset(24)
+            $0.trailing.equalToSuperview().inset(UIDevice.current.isiPhoneSE ? 40 : 24)
         }
         
     }

--- a/WordPalette/WordPalette/Presentation/MyStudy/View/StudyHistoryView.swift
+++ b/WordPalette/WordPalette/Presentation/MyStudy/View/StudyHistoryView.swift
@@ -12,17 +12,21 @@ import SnapKit
 // MARK: - 나의 학습기록 UIView
 final class StudyHistoryView: UIView, UIViewGuide {
     
+    
     /// 배경색
     private let backGroundView = UIView()
     
     /// 타이틀
-    private let titleLabel = PaddingLabel(top: 24, left: 24, bottom: 24, right: 0)
+    private let titleLabel = PaddingLabel(top: 24, left: UIDevice.current.isiPhoneSE ? 36 : 24, bottom: 0, right: 0)
     
     /// 프로필 섹션 뷰
     private let profileSectionView = ProfileSectionView()
     
     /// 달력
     private let calendarView = UICalendarView()
+    
+    /// 달력 배경 (inset을 주고 배경을 깔기 위함)
+    private let calendarBackgroundView = UIView()
     
     func configureAttributes() {
         
@@ -37,10 +41,15 @@ final class StudyHistoryView: UIView, UIViewGuide {
             $0.textColor = .black
             $0.textAlignment = .left
             $0.backgroundColor = .white
-            $0.font = .systemFont(ofSize: 32, weight: .bold)
+            $0.font = .systemFont(ofSize: UIDevice.current.isiPhoneSE ? 24 : 32, weight: .bold)
+        }
+        
+        calendarBackgroundView.do {
+            $0.backgroundColor = .white
         }
         
         calendarView.do {
+            $0.calendar = Calendar(identifier: .gregorian)
             $0.backgroundColor = .white
             $0.locale = Locale(identifier: "ko_KR")
             $0.tintColor = .customOrange
@@ -49,7 +58,7 @@ final class StudyHistoryView: UIView, UIViewGuide {
     }
     
     func configureSubView() {
-        [backGroundView, titleLabel, profileSectionView, calendarView]
+        [backGroundView, titleLabel, profileSectionView, calendarBackgroundView, calendarView]
             .forEach { addSubview($0) }
     }
     
@@ -71,8 +80,15 @@ final class StudyHistoryView: UIView, UIViewGuide {
         
         calendarView.snp.makeConstraints {
             $0.top.equalTo(profileSectionView.snp.bottom).offset(16)
+            $0.horizontalEdges.equalTo(safeAreaLayoutGuide).inset(UIDevice.current.isiPhoneSE ? 40 : 0)
+            $0.height.equalTo(UIDevice.current.isiPhoneSE ? 380 : 480)
+            $0.bottom.equalTo(safeAreaLayoutGuide)
+        }
+        
+        calendarBackgroundView.snp.makeConstraints {
+            $0.top.equalTo(profileSectionView.snp.bottom).offset(16)
             $0.horizontalEdges.equalTo(safeAreaLayoutGuide)
-            $0.bottom.equalTo(safeAreaLayoutGuide).inset(18)
+            $0.bottom.equalTo(safeAreaLayoutGuide)
         }
     }
     

--- a/WordPalette/WordPalette/Presentation/Shared/Extension/Extension+UIDevice.swift
+++ b/WordPalette/WordPalette/Presentation/Shared/Extension/Extension+UIDevice.swift
@@ -1,0 +1,17 @@
+//
+//  Extension+UIDevice.swift
+//  WordPalette
+//
+//  Created by Quarang on 5/26/25.
+//
+
+import UIKit
+
+extension UIDevice {
+    public var isiPhoneSE: Bool {
+        if (UIScreen.main.bounds.size.height == 667 || UIScreen.main.bounds.size.width == 375) {
+            return true
+        }
+        return false
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
- #28
  

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- 아이폰 SE의 경우 달력 잘리는 문제 해결
- 다크모드 일광성 해결

## 📌 구현 내역 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone SE | <img src = "https://github.com/user-attachments/assets/f6029bc7-95f5-49bb-829d-5baebac8b840" width ="250">|
| iPhone 16 Pro | <img src = "https://github.com/user-attachments/assets/7a644cd7-4b54-44a7-96d3-4d615b6b6118" width ="250">|



## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 캘린더의 셀 간격을 컨트롤하려면 iOS 17+ 부터 가능해 캘린더의 크기를 줄이고, 백그라운드를 삽입하는 방식으로 수정
- 추가적으로 SE와 아닌 경우 두가지로 나눠 컴포넌트 크기 및 폰트를 변경하도록 수정
- 탭바에 라이트모드로만 동작하도록 수정

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 없음
