### PR TITLE
[Fix] - #39 bugfix statistics

### DIFF
--- a/WordPalette/WordPalette/Domain/UseCase/StudyHistoryUseCase/StudyHistoryUseCaseImpl.swift
+++ b/WordPalette/WordPalette/Domain/UseCase/StudyHistoryUseCase/StudyHistoryUseCaseImpl.swift
@@ -28,9 +28,10 @@ final class StudyHistoryUseCaseImpl: StudyHistoryUseCase {
     func fetchWords(id: UUID) -> Single<(all: [WordEntity], memos: [WordEntity], unMemos: [WordEntity])>{
         return solvedRepository.fetchWords(id: id)
             .map { words in
-                let memos = words.filter { $0.isCorrect == true }
-                let unMemos = words.filter { $0.isCorrect != true }
-                return (all: words, memos: memos, unMemos: unMemos)
+                let all = Array(words.reversed())
+                let memos = Array(words.filter { $0.isCorrect == true }.reversed())
+                let unMemos = Array(words.filter { $0.isCorrect != true }.reversed())
+                return (all: all, memos: memos, unMemos: unMemos)
             }
     }
 }

--- a/WordPalette/WordPalette/Presentation/MyStudy/Cell/StudyWordCell.swift
+++ b/WordPalette/WordPalette/Presentation/MyStudy/Cell/StudyWordCell.swift
@@ -29,6 +29,7 @@ final class StudyWordCell: UITableViewCell, UIViewGuide {
     func configureAttributes() {
         
         selectionStyle = .none
+        backgroundColor = .clear
         
         wordLabel.do {
             $0.textColor = .black

--- a/WordPalette/WordPalette/Presentation/MyStudy/View/StudyStatisticsView.swift
+++ b/WordPalette/WordPalette/Presentation/MyStudy/View/StudyStatisticsView.swift
@@ -77,6 +77,7 @@ final class StudyStatisticsView: UIView, UIViewGuide {
         
         wordTableView.do {
             $0.rowHeight = 64
+            $0.backgroundColor = .white
         }
         
         dismissButton.do {

--- a/WordPalette/WordPalette/Presentation/MyStudy/ViewController/StudyHistoryViewController.swift
+++ b/WordPalette/WordPalette/Presentation/MyStudy/ViewController/StudyHistoryViewController.swift
@@ -97,6 +97,8 @@ extension StudyHistoryViewController: UICalendarViewDelegate, UICalendarSelectio
               let studyHistory = self.studyHistory.first(where: { Calendar.current.isDate($0.solvedAt, inSameDayAs: date) })
         else { return }
         
+        selection.selectedDate = nil
+        
         // DIContainer 추가하면 바뀔 예정
         let vc = DIContainer.makeStudyStatisticsViewContoller(studyHistory: studyHistory)
         vc.modalPresentationStyle = .fullScreen

--- a/WordPalette/WordPalette/Presentation/MyStudy/ViewController/StudyStatisticsViewController.swift
+++ b/WordPalette/WordPalette/Presentation/MyStudy/ViewController/StudyStatisticsViewController.swift
@@ -57,6 +57,7 @@ final class StudyStatisticsViewController: UIViewController {
         
         // 단어 리스트 바인딩
         viewModel.state.statisticData
+            .observe(on: MainScheduler.asyncInstance)
             .bind(to: studyHistroyView.getWordTableView.rx.items(
                 cellIdentifier: StudyWordCell.identifier,
                 cellType: StudyWordCell.self)) { _, word, cell in
@@ -66,6 +67,7 @@ final class StudyStatisticsViewController: UIViewController {
         
         // 암기/미암기 수량
         viewModel.state.memoStateData
+            .observe(on: MainScheduler.asyncInstance)
             .bind(with: self) { owner, data in
                 let (memo, unMemo) = data
                 owner.studyHistroyView.configure(date: owner.studyHistory.solvedAt, memo: memo, unMemo: unMemo)

--- a/WordPalette/WordPalette/Presentation/MyStudy/ViewModel/StudyStatisticsViewModel.swift
+++ b/WordPalette/WordPalette/Presentation/MyStudy/ViewModel/StudyStatisticsViewModel.swift
@@ -55,12 +55,11 @@ final class StudyStatisticsViewModel: ViewModelType {
         useCase.fetchWords(id: id)
             .subscribe(with: self) { owner, words in
                 let (all, memos, unMemos) = words
-                
                 // 모든 단어 리스트 일단 추가
                 owner.state.statisticData.accept(all)
                 
                 // 모두/암기/미암기 순으로 저장 (필요할 떄마다 statisticData에 저장)
-                [all, memos, unMemos].forEach { owner.words.append($0) }
+                owner.words = [all, memos, unMemos]
                 
                 // 암기/미암기 수량 저장
                 owner.state.memoStateData.accept((memos.count, unMemos.count))
@@ -70,6 +69,7 @@ final class StudyStatisticsViewModel: ViewModelType {
     
     /// 단어 리스트 저장
     private func setWordList(index: Int) {
+        guard !words.isEmpty else { return }
         state.statisticData.accept(words[index])
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  - #39

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- 달력에서 날짜 선택 시 런타임 에러 발생
- UI를 백그라운드에서 업데이트할 때 스레드 충돌이 발생
- 혹은 단어 리스트를 모델에 저장하기 전에 세그먼트 컨트롤이 해당 모델에 접근 (out of range)
- 라이트 모드 일관성 준수


## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- UI 업데이트 부분은 MainScheduler로 지정했습니다.
- 추가적으로 달력에서 날짜를 선택했을 때 날짜 데이터를 유지해서 선택한 날짜 중복 터치가 안됐던 문제를 해결했습니다.
- 단어리스트를 불러오기 전에 세그먼트 컨트롤의 접근을 방지했습니다.
- 단어 리스트는 최근 추가 순으로 정렬 되도록 수정했습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 없음