### PR TITLE
[Feat] - #40 home화면 UI 수정

### DIFF
--- a/WordPalette/WordPalette/Presentation/Components/LevelButtonView.swift
+++ b/WordPalette/WordPalette/Presentation/Components/LevelButtonView.swift
@@ -22,7 +22,7 @@ final class LevelButtonView: UIView {
             $0.setTitle(level.rawValue, for: .normal)
             $0.setTitleColor(.white, for: .normal)
             $0.titleLabel?.font = .boldSystemFont(ofSize: 16)
-            $0.layer.cornerRadius = 12
+            $0.layer.cornerRadius = 16
             $0.clipsToBounds = true
         }
         return button

--- a/WordPalette/WordPalette/Presentation/Components/LevelButtonView.swift
+++ b/WordPalette/WordPalette/Presentation/Components/LevelButtonView.swift
@@ -21,7 +21,7 @@ final class LevelButtonView: UIView {
         let button = UIButton().then {
             $0.setTitle(level.rawValue, for: .normal)
             $0.setTitleColor(.white, for: .normal)
-            $0.titleLabel?.font = .boldSystemFont(ofSize: 16)
+            $0.titleLabel?.font = .systemFont(ofSize: 16, weight: .heavy)
             $0.layer.cornerRadius = 16
             $0.clipsToBounds = true
         }

--- a/WordPalette/WordPalette/Presentation/Components/LevelButtonView.swift
+++ b/WordPalette/WordPalette/Presentation/Components/LevelButtonView.swift
@@ -51,9 +51,22 @@ final class LevelButtonView: UIView {
     func updateButtonSelection(selected: Level) {
         for (index, button) in levelButtons.enumerated() {
             let level = levels[index]
-            button.backgroundColor = (level == selected) ? .customMango : .systemGray5
+
+            if level == selected {
+                switch level {
+                case .beginner:
+                    button.backgroundColor = .customBanana
+                case .intermediate:
+                    button.backgroundColor = .customOrange
+                case .advanced:
+                    button.backgroundColor = .customStrawBerry
+                }
+            } else {
+                button.backgroundColor = .systemGray5
+            }
         }
     }
+
 
     // 버튼이 눌렸음을 Rx로 나타내는 메서드
     func bindButtonTapped() -> Observable<Level> {

--- a/WordPalette/WordPalette/Presentation/Home/View/HomeView.swift
+++ b/WordPalette/WordPalette/Presentation/Home/View/HomeView.swift
@@ -89,7 +89,7 @@ final class HomeView: UIView {
         ].forEach { addSubview($0) }
 
         addWordLabel.snp.makeConstraints {
-            $0.top.equalTo(safeAreaLayoutGuide).offset(24)
+            $0.top.equalTo(safeAreaLayoutGuide)
             $0.leading.equalTo(safeAreaLayoutGuide).offset(24)
         }
 
@@ -107,7 +107,7 @@ final class HomeView: UIView {
         levelButtonView.snp.makeConstraints {
             $0.top.equalTo(myWordLabel.snp.bottom).offset(18)
             $0.horizontalEdges.equalTo(safeAreaLayoutGuide).inset(24)
-            $0.height.equalTo(28)
+            $0.height.equalTo(32)
         }
 
         myWordTableView.snp.makeConstraints {

--- a/WordPalette/WordPalette/Presentation/Home/View/HomeView.swift
+++ b/WordPalette/WordPalette/Presentation/Home/View/HomeView.swift
@@ -9,7 +9,7 @@ final class HomeView: UIView {
     /// 단어 추가 label
     private let addWordLabel = UILabel().then {
         $0.text = "단어 추가"
-        $0.font = .boldSystemFont(ofSize: 32)
+        $0.font = .systemFont(ofSize: 32, weight: .heavy)
         $0.textColor = .black
     }
 
@@ -25,7 +25,7 @@ final class HomeView: UIView {
         let button = UIButton().then {
             $0.setTitle(level.rawValue, for: .normal)
             $0.setTitleColor(.white, for: .normal)
-            $0.titleLabel?.font = .boldSystemFont(ofSize: 26)
+            $0.titleLabel?.font = .systemFont(ofSize: 26, weight: .heavy)
             $0.layer.cornerRadius = 12
             $0.clipsToBounds = true
             $0.backgroundColor = {
@@ -42,7 +42,7 @@ final class HomeView: UIView {
     /// 내 단어장 label
     private let myWordLabel = UILabel().then {
         $0.text = "내 단어장"
-        $0.font = .boldSystemFont(ofSize: 32)
+        $0.font = .systemFont(ofSize: 32, weight: .heavy)
         $0.textColor = .black
     }
 
@@ -59,7 +59,7 @@ final class HomeView: UIView {
     let deleteAllButton = UIButton().then {
         $0.setTitle("전체 삭제", for: .normal)
         $0.setTitleColor(.white, for: .normal)
-        $0.titleLabel?.font = .boldSystemFont(ofSize: 18)
+        $0.titleLabel?.font = .systemFont(ofSize: 18, weight: .semibold)
         $0.backgroundColor = .customOrange
         $0.layer.cornerRadius = 12
         $0.clipsToBounds = true

--- a/WordPalette/WordPalette/Presentation/Home/ViewController/HomeViewController.swift
+++ b/WordPalette/WordPalette/Presentation/Home/ViewController/HomeViewController.swift
@@ -84,6 +84,11 @@ final class HomeViewController: UIViewController {
         zip(homeView.levelSearchButtons, homeView.levels).forEach { button, level in
             button.rx.tap
                 .bind(with: self) { owner, _ in
+                    // VM 상태 변경
+                    owner.homeViewModel.selectedLevelRelay.accept(level)
+                    // 버튼 UI 즉시 업데이트
+                    owner.homeView.levelButtonView.updateButtonSelection(selected: level)
+
                     let addWordVC = self.diContainer.makeAddWordViewController(selectedLevel: level) // 레벨별 검색 페이지로 이동
                     owner.navigationController?.pushViewController(addWordVC, animated: true)
                 }

--- a/WordPalette/WordPalette/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/WordPalette/WordPalette/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -24,6 +24,9 @@ final class HomeViewModel {
                 guard let self = self else { return .just([]) }
                 return self.unsolvedMyWordUseCase.fetchWords(by: level)
             }
+            .map { wordList in
+                return wordList.sorted { $0.word.lowercased() < $1.word.lowercased() }
+            } // 저장된 단어 오름차순 정렬
             .bind(to: wordListRelay)
             .disposed(by: disposeBag)
     }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  closed: #40 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- inset 삭제하여 전체적인 UI 상단으로 올렸습니다.
- 테이블 뷰 셀을 알파벳 기준으로 오름차순 정렬했습니다.
- 내 단어장 레별 버튼의 UI 수정 및 배경색 변경했습니다.
- 단어 찾기 버튼을 누르면 내 단어장도 해당 레벨의 테이블뷰를 홈화면에 보여줍니다.

## 📌 구현 내역 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src = "https://github.com/user-attachments/assets/e60e008d-0f07-431a-aa7d-c884daa5f55b" width ="250">|


## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->


## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
