### PR TITLE
[FEAT] #38 - 단어 추가 시 Alert -> TostMesage로 변경

### DIFF
--- a/WordPalette/WordPalette/Presentation/AddWord/ViewController/AddWordViewController.swift
+++ b/WordPalette/WordPalette/Presentation/AddWord/ViewController/AddWordViewController.swift
@@ -57,6 +57,11 @@ final class AddWordViewController: UIViewController {
         viewWillAppearSubject.onNext(())
     }
     
+    override func viewDidDisappear(_ animated: Bool) {
+        navigationController?.popViewController(animated: false)
+      }
+
+    
     // MARK: - Setup
     private func setupTableViewCell() {
         addWordView.tableView.register(TableViewWordCell.self, forCellReuseIdentifier: TableViewWordCell.id)

--- a/WordPalette/WordPalette/Presentation/AddWord/ViewController/AddWordViewController.swift
+++ b/WordPalette/WordPalette/Presentation/AddWord/ViewController/AddWordViewController.swift
@@ -102,7 +102,7 @@ final class AddWordViewController: UIViewController {
     private func bindOutput(_ output: AddWordViewModel.Output) {
         bindWordsOutput(output.words)
         bindAddResultOutput(output.addResult)
-        bindAlertOutput(output.showAlert)
+        bindResultMessage(output.resultMessage)
     }
     
     // MARK: - Individual Input Bindings
@@ -165,11 +165,11 @@ final class AddWordViewController: UIViewController {
     }
     
     /// Alert 메시지 바인딩
-    private func bindAlertOutput(_ showAlert: Observable<String>) {
-        showAlert
+    private func bindResultMessage(_ showToast: Observable<String>) {
+        showToast
             .observe(on: MainScheduler.instance)
             .bind(with: self) { owner, message in
-                owner.showAlert(message: message)
+                owner.showToast(message: message)
             }
             .disposed(by: disposeBag)
     }
@@ -213,32 +213,8 @@ final class AddWordViewController: UIViewController {
     }
     
     /// Alert 표시
-    private func showAlert(message: String) {
-        // 이미 Alert가 표시 중인지 확인 (Alert 중복 방지)
-        if presentedViewController != nil {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
-                self?.showAlert(message: message)
-            }
-            return
-        }
-        
-        let alert = UIAlertController(title: "알림", message: message, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "확인", style: .default))
-        present(alert, animated: true)
-    }
-    
-    /// 단어 저장 확인 Alert 표시
-    private func showAddWordAlert(word: WordEntity) {
-        let alert = UIAlertController(
-            title: "내 단어장에 저장",
-            message: "\(word.word)을(를) 내 단어장에 저장하시겠습니까?",
-            preferredStyle: .alert
-        )
-        alert.addAction(UIAlertAction(title: "취소", style: .cancel))
-        alert.addAction(UIAlertAction(title: "확인", style: .default, handler: { [weak self] _ in
-            self?.addWordTapSubject.onNext(word)
-        }))
-        present(alert, animated: true)
+    private func resultMessage(message: String) {
+        showToast(message: message)
     }
 }
 
@@ -270,7 +246,7 @@ extension AddWordViewController: UITableViewDataSource, UITableViewDelegate {
         cell.addButtonTap
             .bind(with: self) { owner, _ in
                 owner.addedWordIndexPath = indexPath
-                owner.showAddWordAlert(word: data)
+                owner.addWordTapSubject.onNext(data)
             }
             .disposed(by: cell.disposeBag)
         

--- a/WordPalette/WordPalette/Presentation/AddWord/ViewModel/AddWordViewModel.swift
+++ b/WordPalette/WordPalette/Presentation/AddWord/ViewModel/AddWordViewModel.swift
@@ -30,13 +30,13 @@ final class AddWordViewModel {
     struct Output {
         let words: Observable<[WordEntity]>
         let addResult: Observable<AddWordResult>
-        let showAlert: Observable<String>
+        let resultMessage: Observable<String>
     }
     
     // MARK: - Output Subjects
     private let wordsSubject = BehaviorSubject<[WordEntity]>(value: [])
     private let addResultSubject = PublishSubject<AddWordResult>()
-    private let showAlertSubject = PublishSubject<String>()
+    private let resultMessageSubject = PublishSubject<String>()
     
     // MARK: - Properties
     private let useCase: AddWordUseCase
@@ -55,12 +55,12 @@ final class AddWordViewModel {
         bindSearch(input: input)
         bindAddWord(input: input)
         bindAddCustomWord(input: input)
-        bindAlert()
+        bindResultMessage()
         
         return Output(
             words: wordsSubject.asObservable(),
             addResult: addResultSubject.asObservable(),
-            showAlert: showAlertSubject.asObservable()
+            resultMessage: resultMessageSubject.asObservable()
         )
     }
     
@@ -127,16 +127,17 @@ final class AddWordViewModel {
             .disposed(by: disposeBag)
     }
     
-    // 6. 결과에 따라 Alert 출력
-    private func bindAlert() {
+    // 6. 결과에 따라 Toast 출력
+    private func bindResultMessage() {
         addResultSubject
             .compactMap { result in
                 switch result {
-                case .success: return "단어가 저장되었습니다."
+                case .success(let wordEntity):
+                    return "\(wordEntity.word) 단어가 저장되었습니다."
                 case .failure(let message): return message
                 }
             }
-            .bind(to: showAlertSubject)
+            .bind(to: resultMessageSubject)
             .disposed(by: disposeBag)
     }
 }

--- a/WordPalette/WordPalette/Presentation/Shared/Extension/Extension+Toast.swift
+++ b/WordPalette/WordPalette/Presentation/Shared/Extension/Extension+Toast.swift
@@ -1,0 +1,46 @@
+//
+//  Extension+Toast.swift
+//  WordPalette
+//
+//  Created by iOS study on 5/27/25.
+//
+
+import UIKit
+
+extension UIViewController {
+    func showToast(message: String, duration: Double = 2.0) {
+        let toastLabel = UILabel()
+        toastLabel.text = message
+        toastLabel.backgroundColor = UIColor.white.withAlphaComponent(1.0)
+        toastLabel.textColor = .black
+        toastLabel.textAlignment = .center
+        toastLabel.font = UIFont.systemFont(ofSize: 14)
+        toastLabel.alpha = 0.0
+        toastLabel.layer.cornerRadius = 10
+        toastLabel.clipsToBounds = true
+
+        let maxWidth = view.frame.size.width * 0.8
+        let maxSize = CGSize(width: maxWidth, height: view.frame.size.height)
+        var expectedSize = toastLabel.sizeThatFits(maxSize)
+        expectedSize.width += 32
+        expectedSize.height += 16
+
+        toastLabel.frame = CGRect(
+            x: (view.frame.size.width - expectedSize.width) / 2,
+            y: view.frame.size.height - expectedSize.height - 180,
+            width: expectedSize.width,
+            height: expectedSize.height
+        )
+
+        view.addSubview(toastLabel)
+        UIView.animate(withDuration: 0.3, animations: {
+            toastLabel.alpha = 1.0
+        }) { _ in
+            UIView.animate(withDuration: 0.3, delay: duration, options: .curveEaseOut, animations: {
+                toastLabel.alpha = 0.0
+            }) { _ in
+                toastLabel.removeFromSuperview()
+            }
+        }
+    }
+}

--- a/WordPalette/WordPalette/Presentation/Shared/Extension/Extension+Toast.swift
+++ b/WordPalette/WordPalette/Presentation/Shared/Extension/Extension+Toast.swift
@@ -9,7 +9,13 @@ import UIKit
 
 extension UIViewController {
     func showToast(message: String, duration: Double = 2.0) {
+        // 기존 토스트 즉시 제거 (애니메이션 중이어도 강제 제거)
+        if let existingToast = view.viewWithTag(9999) {
+            existingToast.removeFromSuperview()
+        }
+        
         let toastLabel = UILabel()
+        toastLabel.tag = 9999
         toastLabel.text = message
         toastLabel.backgroundColor = UIColor.white.withAlphaComponent(1.0)
         toastLabel.textColor = .black
@@ -33,10 +39,10 @@ extension UIViewController {
         )
 
         view.addSubview(toastLabel)
-        UIView.animate(withDuration: 0.3, animations: {
+        UIView.animate(withDuration: 0.2, animations: {
             toastLabel.alpha = 1.0
         }) { _ in
-            UIView.animate(withDuration: 0.3, delay: duration, options: .curveEaseOut, animations: {
+            UIView.animate(withDuration: 0.2, delay: duration, options: .curveEaseOut, animations: {
                 toastLabel.alpha = 0.0
             }) { _ in
                 toastLabel.removeFromSuperview()


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
closed: #38 
  

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
1. 단어 추가 시 Alert -> Toast로 Result Message 출력 방식 변경
2. 단어 추가 화면에서 탭바 이동 시 화면 pop 되어 홈탭바 누르면 항상 메인 화면 보이도록 설정


## 📌 구현 내역 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src = "https://github.com/user-attachments/assets/57dcf5d6-c5ca-45b0-bad0-2c754d0ef9f1" width ="250">|


## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
개선사항 있다면 말씀 드립니다
