### PR TITLE
[Feat] - #47 home UI 최종 수정

### DIFF
--- a/WordPalette/WordPalette/Presentation/Components/LevelButtonView.swift
+++ b/WordPalette/WordPalette/Presentation/Components/LevelButtonView.swift
@@ -62,7 +62,7 @@ final class LevelButtonView: UIView {
                     button.backgroundColor = .customStrawBerry
                 }
             } else {
-                button.backgroundColor = .systemGray5
+                button.backgroundColor = .systemGray2
             }
         }
     }

--- a/WordPalette/WordPalette/Presentation/Home/View/HomeView.swift
+++ b/WordPalette/WordPalette/Presentation/Home/View/HomeView.swift
@@ -6,38 +6,38 @@ final class HomeView: UIView {
     /// Level 배열
     let levels: [Level] = [.beginner, .intermediate, .advanced]
 
-    /// 단어 추가 label
-    private let addWordLabel = UILabel().then {
-        $0.text = "단어 추가"
-        $0.font = .systemFont(ofSize: 32, weight: .heavy)
-        $0.textColor = .black
-    }
+//    /// 단어 추가 label
+//    private let addWordLabel = UILabel().then {
+//        $0.text = "단어 추가"
+//        $0.font = .systemFont(ofSize: 32, weight: .heavy)
+//        $0.textColor = .black
+//    }
 
-    /// 레벨별로 단어를 검색해서 추가하는 페이지로 가기 위한 버튼 묶음 stackView
-    private lazy var levelSearchButtonStackView = UIStackView(arrangedSubviews: levelSearchButtons).then {
-        $0.axis = .horizontal
-        $0.spacing = 40
-        $0.distribution = .fillEqually
-    }
+//    /// 레벨별로 단어를 검색해서 추가하는 페이지로 가기 위한 버튼 묶음 stackView
+//    private lazy var levelSearchButtonStackView = UIStackView(arrangedSubviews: levelSearchButtons).then {
+//        $0.axis = .horizontal
+//        $0.spacing = 40
+//        $0.distribution = .fillEqually
+//    }
 
-    /// 레벨별 검색 페이지 버튼 배열 (초급, 중급, 고급)
-    lazy var levelSearchButtons: [UIButton] = levels.map { level in
-        let button = UIButton().then {
-            $0.setTitle(level.rawValue, for: .normal)
-            $0.setTitleColor(.white, for: .normal)
-            $0.titleLabel?.font = .systemFont(ofSize: 26, weight: .heavy)
-            $0.layer.cornerRadius = 12
-            $0.clipsToBounds = true
-            $0.backgroundColor = {
-                switch level {
-                case .beginner: return .customBanana
-                case .intermediate: return .customOrange
-                case .advanced: return .customStrawBerry
-                }
-            }()
-        }
-        return button
-    }
+//    /// 레벨별 검색 페이지 버튼 배열 (초급, 중급, 고급)
+//    lazy var levelSearchButtons: [UIButton] = levels.map { level in
+//        let button = UIButton().then {
+//            $0.setTitle(level.rawValue, for: .normal)
+//            $0.setTitleColor(.white, for: .normal)
+//            $0.titleLabel?.font = .systemFont(ofSize: 26, weight: .heavy)
+//            $0.layer.cornerRadius = 12
+//            $0.clipsToBounds = true
+//            $0.backgroundColor = {
+//                switch level {
+//                case .beginner: return .customBanana
+//                case .intermediate: return .customOrange
+//                case .advanced: return .customStrawBerry
+//                }
+//            }()
+//        }
+//        return button
+//    }
 
     /// 내 단어장 label
     private let myWordLabel = UILabel().then {
@@ -55,13 +55,30 @@ final class HomeView: UIView {
         $0.backgroundColor = .clear
     }
 
+    /// 홈 화면 버튼 묶음 stackView
+    private lazy var homeButtonStackView = UIStackView(arrangedSubviews: [toAddWordButton, deleteAllButton]).then {
+        $0.axis = .horizontal
+        $0.spacing = 10
+        $0.distribution = .fillEqually
+    }
+
+    /// 단어 추가 페이지로 넘어가는 버튼
+    let toAddWordButton = UIButton().then {
+        $0.setTitle("단어 추가", for: .normal)
+        $0.setTitleColor(.white, for: .normal)
+        $0.titleLabel?.font = .systemFont(ofSize: 18, weight: .semibold)
+        $0.backgroundColor = .customOrange
+        $0.layer.cornerRadius = 10
+        $0.clipsToBounds = true
+    }
+
     /// 전체 삭제 버튼
     let deleteAllButton = UIButton().then {
         $0.setTitle("전체 삭제", for: .normal)
         $0.setTitleColor(.white, for: .normal)
         $0.titleLabel?.font = .systemFont(ofSize: 18, weight: .semibold)
-        $0.backgroundColor = .customOrange
-        $0.layer.cornerRadius = 12
+        $0.backgroundColor = .systemGray
+        $0.layer.cornerRadius = 10
         $0.clipsToBounds = true
     }
 
@@ -80,27 +97,28 @@ final class HomeView: UIView {
         backgroundColor = .white
 
         [
-            addWordLabel,
-            levelSearchButtonStackView,
+//            addWordLabel,
+//            levelSearchButtonStackView,
             myWordLabel,
             levelButtonView,
             myWordTableView,
-            deleteAllButton
+            homeButtonStackView
         ].forEach { addSubview($0) }
 
-        addWordLabel.snp.makeConstraints {
-            $0.top.equalTo(safeAreaLayoutGuide)
-            $0.leading.equalTo(safeAreaLayoutGuide).offset(24)
-        }
-
-        levelSearchButtonStackView.snp.makeConstraints {
-            $0.top.equalTo(addWordLabel.snp.bottom).offset(18)
-            $0.horizontalEdges.equalTo(safeAreaLayoutGuide).inset(24)
-            $0.height.equalTo(levelSearchButtonStackView.snp.width).dividedBy(4)
-        }
+//        addWordLabel.snp.makeConstraints {
+//            $0.top.equalTo(safeAreaLayoutGuide)
+//            $0.leading.equalTo(safeAreaLayoutGuide).offset(24)
+//        }
+//
+//        levelSearchButtonStackView.snp.makeConstraints {
+//            $0.top.equalTo(addWordLabel.snp.bottom).offset(18)
+//            $0.horizontalEdges.equalTo(safeAreaLayoutGuide).inset(24)
+//            $0.height.equalTo(levelSearchButtonStackView.snp.width).dividedBy(4)
+//        }
 
         myWordLabel.snp.makeConstraints {
-            $0.top.equalTo(levelSearchButtonStackView.snp.bottom).offset(24)
+            $0.top.equalTo(safeAreaLayoutGuide)
+//            $0.top.equalTo(levelSearchButtonStackView.snp.bottom).offset(24)
             $0.leading.equalTo(safeAreaLayoutGuide).offset(24)
         }
 
@@ -116,10 +134,10 @@ final class HomeView: UIView {
             $0.bottom.equalTo(deleteAllButton.snp.top).offset(-18)
         }
 
-        deleteAllButton.snp.makeConstraints {
+        homeButtonStackView.snp.makeConstraints {
             $0.horizontalEdges.equalTo(safeAreaLayoutGuide).inset(24)
-            $0.height.equalTo(55)
-            $0.bottom.equalTo(safeAreaLayoutGuide).offset(-18)
+            $0.height.equalTo(54)
+            $0.bottom.equalTo(safeAreaLayoutGuide).offset(-10)
         }
     }
 }

--- a/WordPalette/WordPalette/Presentation/Home/View/HomeView.swift
+++ b/WordPalette/WordPalette/Presentation/Home/View/HomeView.swift
@@ -44,7 +44,7 @@ final class HomeView: UIView {
         $0.setTitle("전체 삭제", for: .normal)
         $0.setTitleColor(.white, for: .normal)
         $0.titleLabel?.font = .systemFont(ofSize: 18, weight: .semibold)
-        $0.backgroundColor = .systemGray
+        $0.backgroundColor = .systemGray2
         $0.layer.cornerRadius = 10
         $0.clipsToBounds = true
     }

--- a/WordPalette/WordPalette/Presentation/Home/View/HomeView.swift
+++ b/WordPalette/WordPalette/Presentation/Home/View/HomeView.swift
@@ -6,39 +6,6 @@ final class HomeView: UIView {
     /// Level 배열
     let levels: [Level] = [.beginner, .intermediate, .advanced]
 
-//    /// 단어 추가 label
-//    private let addWordLabel = UILabel().then {
-//        $0.text = "단어 추가"
-//        $0.font = .systemFont(ofSize: 32, weight: .heavy)
-//        $0.textColor = .black
-//    }
-
-//    /// 레벨별로 단어를 검색해서 추가하는 페이지로 가기 위한 버튼 묶음 stackView
-//    private lazy var levelSearchButtonStackView = UIStackView(arrangedSubviews: levelSearchButtons).then {
-//        $0.axis = .horizontal
-//        $0.spacing = 40
-//        $0.distribution = .fillEqually
-//    }
-
-//    /// 레벨별 검색 페이지 버튼 배열 (초급, 중급, 고급)
-//    lazy var levelSearchButtons: [UIButton] = levels.map { level in
-//        let button = UIButton().then {
-//            $0.setTitle(level.rawValue, for: .normal)
-//            $0.setTitleColor(.white, for: .normal)
-//            $0.titleLabel?.font = .systemFont(ofSize: 26, weight: .heavy)
-//            $0.layer.cornerRadius = 12
-//            $0.clipsToBounds = true
-//            $0.backgroundColor = {
-//                switch level {
-//                case .beginner: return .customBanana
-//                case .intermediate: return .customOrange
-//                case .advanced: return .customStrawBerry
-//                }
-//            }()
-//        }
-//        return button
-//    }
-
     /// 내 단어장 label
     private let myWordLabel = UILabel().then {
         $0.text = "내 단어장"
@@ -56,14 +23,14 @@ final class HomeView: UIView {
     }
 
     /// 홈 화면 버튼 묶음 stackView
-    private lazy var homeButtonStackView = UIStackView(arrangedSubviews: [toAddWordButton, deleteAllButton]).then {
+    private lazy var homeButtonStackView = UIStackView(arrangedSubviews: [toSearchWordButton, deleteAllButton]).then {
         $0.axis = .horizontal
         $0.spacing = 10
         $0.distribution = .fillEqually
     }
 
     /// 단어 추가 페이지로 넘어가는 버튼
-    let toAddWordButton = UIButton().then {
+    let toSearchWordButton = UIButton().then {
         $0.setTitle("단어 추가", for: .normal)
         $0.setTitleColor(.white, for: .normal)
         $0.titleLabel?.font = .systemFont(ofSize: 18, weight: .semibold)
@@ -97,41 +64,27 @@ final class HomeView: UIView {
         backgroundColor = .white
 
         [
-//            addWordLabel,
-//            levelSearchButtonStackView,
             myWordLabel,
             levelButtonView,
             myWordTableView,
             homeButtonStackView
         ].forEach { addSubview($0) }
 
-//        addWordLabel.snp.makeConstraints {
-//            $0.top.equalTo(safeAreaLayoutGuide)
-//            $0.leading.equalTo(safeAreaLayoutGuide).offset(24)
-//        }
-//
-//        levelSearchButtonStackView.snp.makeConstraints {
-//            $0.top.equalTo(addWordLabel.snp.bottom).offset(18)
-//            $0.horizontalEdges.equalTo(safeAreaLayoutGuide).inset(24)
-//            $0.height.equalTo(levelSearchButtonStackView.snp.width).dividedBy(4)
-//        }
-
         myWordLabel.snp.makeConstraints {
             $0.top.equalTo(safeAreaLayoutGuide)
-//            $0.top.equalTo(levelSearchButtonStackView.snp.bottom).offset(24)
             $0.leading.equalTo(safeAreaLayoutGuide).offset(24)
         }
 
         levelButtonView.snp.makeConstraints {
-            $0.top.equalTo(myWordLabel.snp.bottom).offset(18)
+            $0.top.equalTo(myWordLabel.snp.bottom).offset(16)
             $0.horizontalEdges.equalTo(safeAreaLayoutGuide).inset(24)
             $0.height.equalTo(32)
         }
 
         myWordTableView.snp.makeConstraints {
-            $0.top.equalTo(levelButtonView.snp.bottom).offset(24)
+            $0.top.equalTo(levelButtonView.snp.bottom).offset(16)
             $0.horizontalEdges.equalTo(safeAreaLayoutGuide)
-            $0.bottom.equalTo(deleteAllButton.snp.top).offset(-18)
+            $0.bottom.equalTo(deleteAllButton.snp.top).offset(-16)
         }
 
         homeButtonStackView.snp.makeConstraints {

--- a/WordPalette/WordPalette/Presentation/Home/ViewController/HomeViewController.swift
+++ b/WordPalette/WordPalette/Presentation/Home/ViewController/HomeViewController.swift
@@ -81,19 +81,13 @@ final class HomeViewController: UIViewController {
 
     /// 단어 검색 페이지로 넘어가는 메서드
     private func bindToSearchButton() {
-        zip(homeView.levelSearchButtons, homeView.levels).forEach { button, level in
-            button.rx.tap
-                .bind(with: self) { owner, _ in
-                    // VM 상태 변경
-                    owner.homeViewModel.selectedLevelRelay.accept(level)
-                    // 버튼 UI 즉시 업데이트
-                    owner.homeView.levelButtonView.updateButtonSelection(selected: level)
-
-                    let addWordVC = self.diContainer.makeAddWordViewController(selectedLevel: level) // 레벨별 검색 페이지로 이동
-                    owner.navigationController?.pushViewController(addWordVC, animated: true)
-                }
-                .disposed(by: disposeBag)
-        }
+        homeView.toSearchWordButton.rx.tap
+            .withLatestFrom(homeViewModel.selectedLevelRelay) // 가장 최근에 선택된 레벨
+            .bind(with: self) { owner, level in
+                let addWordVC = self.diContainer.makeAddWordViewController(selectedLevel: level) // 레벨별 검색 페이지로 이동
+                owner.navigationController?.pushViewController(addWordVC, animated: true)
+            }
+            .disposed(by: disposeBag)
     }
 
     /// Cell별 Data 바인딩 메서드

--- a/WordPalette/WordPalette/Presentation/Home/ViewController/HomeViewController.swift
+++ b/WordPalette/WordPalette/Presentation/Home/ViewController/HomeViewController.swift
@@ -153,14 +153,16 @@ extension HomeViewController: UITableViewDelegate {
         _ tableView: UITableView,
         trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath
     ) -> UISwipeActionsConfiguration? {
-        let delete = UIContextualAction(style: .destructive, title: "삭제") { [weak self] _, _, completion in
+        let delete = UIContextualAction(style: .destructive, title: nil) { [weak self] _, _, completion in
             guard let self = self else { return }
             let word = self.homeViewModel.wordListRelay.value[indexPath.row]
             self.homeViewModel.deleteWord(word)
             completion(true)
         }
 
-        delete.backgroundColor = .customOrange
+        delete.image = UIImage(systemName: "trash")
+        delete.backgroundColor = .systemGray2
+
         return UISwipeActionsConfiguration(actions: [delete])
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  closed: #47 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- 내 단어장에 저장된 단어들 한눈에 더 많이 보기 위해 UI 수정했습니다.
- 기능은 직전과 동일합니다.
- 스와이프 삭제를 직관적으로 보이기 위해 "삭제" 텍스트 대신 trash 이미지를 넣었습니다.
- 전체적인 홈화면 색상을 통일했습니다.

## 📌 구현 내역 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src = "https://github.com/user-attachments/assets/e2c54093-1379-4a5c-9dd2-91c638d20a53" width ="250">|


## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->


## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
